### PR TITLE
fix in json unmarshaling for k8s resource

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -20,6 +20,9 @@ type KubernetesResource struct {
 	APIVersion string      `json:"apiVersion,omitempty"`
 	Metadata   Metadata    `json:"metadata,omitempty"`
 	Spec       interface{} `json:"spec,omitempty"`
+	Data       interface{} `json:"data,omitempty"`
+	Template   interface{} `json:"template,omitempty"`
+	Items      interface{} `json:"items,omitempty"`
 }
 
 func InjectNamespaceToString(originalConfig string, namespace string) string {


### PR DESCRIPTION
This PR covers 2 things:

1) Labels injection: field passed to 'catalog' endpoint. Done to support grouping resources of the same catalog endpoint. UI will send 'io.rancher.stack'=<stackName> along with the template to the kubectl, and the label will be injected to every resource defined in the file(s) @vincent99 

2) fix for the https://github.com/rancher/rancher/issues/5293