### PR TITLE
pass namespace to kubectl command (when specified)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -62,12 +62,17 @@ func (s *Server) Post(rw http.ResponseWriter, r *http.Request) {
 	} else {
 		args = append(args, "-f", "-")
 	}
+	ns := r.FormValue(defaultNamespace)
+	if ns != "" {
+		args = append(args, "-n", ns)
+	}
+
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		writeError(rw, err)
 		return
 	}
-	modifiedConfig := string(stack.InjectNamespace(b, r.FormValue(defaultNamespace)))
+	modifiedConfig := string(stack.InjectNamespace(b, ns))
 	output := cli.Kubectl(strings.NewReader(modifiedConfig), args...)
 	writeResponse(rw, output, 203)
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/6405

When read arguments on delete (POST), account for defaultNamespace param that can be present in the request as well