### PR TITLE
Adds ca root update

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,6 +4,9 @@ RUN apt-get update && \
 RUN apt-get install -y bash-completion
 RUN wget -O /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.4.4/bin/linux/amd64/kubectl && \
     chmod +x /usr/bin/kubectl
+ENV SSL_SCRIPT_COMMIT 98660ada3d800f653fc1f105771b5173f9d1a019
+RUN wget -O /usr/bin/update-rancher-ssl https://raw.githubusercontent.com/rancher/rancher/${SSL_SCRIPT_COMMIT}/server/bin/update-rancher-ssl && \
+    chmod +x /usr/bin/update-rancher-ssl
 ENV KUBE_SERVER http://localhost:8080
 COPY kubectld /usr/bin/
 COPY kubectld.sh /usr/bin

--- a/package/kubectld.sh
+++ b/package/kubectld.sh
@@ -16,4 +16,6 @@ contexts:
 current-context: "Default"
 EOF
 
+/usr/bin/update-rancher-ssl
+
 exec kubectld --server=$SERVER --listen=$LISTEN


### PR DESCRIPTION
If a user is running an internal or other non-public CA this will
configure the container to trust the root CA.