### PR TITLE
Two handy aliases

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -20,6 +20,8 @@ ENV LISTEN :8091
 ENV HOME /tmp
 RUN cp /etc/skel/.bashrc /tmp/ && \
     echo 'PS1="> "' >> /tmp/.bashrc && \
-    echo . /etc/bash_completion >> /tmp/.bashrc
+    echo . /etc/bash_completion >> /tmp/.bashrc && \
+    echo 'alias k="kubectl"' >> /tmp/.bashrc && \
+    echo 'alias ks="kubectl -n kube-system"' >> /tmp/.bashrc
 WORKDIR $HOME 
 CMD ["kubectld.sh"]


### PR DESCRIPTION
`k` -> `kubectl`
`ks` -> `kubectl -n kube-system`

These are really handy. Would be great to have these out of the box in kubectl shell.