### PR TITLE
Helm 2.3.0

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
 RUN apt-get install -y bash-completion
 RUN wget -O /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kubectl && \
     chmod +x /usr/bin/kubectl
-RUN wget -O helm.tar.gz http://storage.googleapis.com/kubernetes-helm/helm-v2.2.3-linux-amd64.tar.gz && \
+RUN wget -O helm.tar.gz http://storage.googleapis.com/kubernetes-helm/helm-v2.3.0-linux-amd64.tar.gz && \
     tar xvzf helm.tar.gz && \
     mv ./linux-amd64/helm /usr/bin/ && \
     chmod +x /usr/bin/helm


### PR DESCRIPTION
Needs to be released at the same time as https://github.com/rancher/kubernetes-package/pull/59